### PR TITLE
Add env configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_API_URL=http://localhost:8080/api
+VITE_MEDIA_URL=http://localhost:8080

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Ignore environment files
+.env

--- a/README.md
+++ b/README.md
@@ -11,3 +11,15 @@ Currently, two official plugins are available:
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
 # Oricand-Frontend-V2
+
+## Environment Variables
+
+Create a `.env` file based on `.env.example` and adjust the URLs if needed:
+
+```
+VITE_API_URL=http://localhost:8080/api
+VITE_MEDIA_URL=http://localhost:8080
+```
+
+`VITE_API_URL` points to the API base URL used by Axios while
+`VITE_MEDIA_URL` is prefixed to media paths such as images or videos.

--- a/src/components/cart/CartTable.jsx
+++ b/src/components/cart/CartTable.jsx
@@ -28,7 +28,7 @@ export default function CartTable({ entries, compact = false }) {
                 {/* product */}
                 <td className="py-4 flex items-center gap-4">
                   <img
-                    src={`http://localhost:8080${product.featuredImageUrl}`}
+                    src={`${import.meta.env.VITE_MEDIA_URL}${product.featuredImageUrl}`}
                     alt={product.name}
                     className="w-16 h-16 object-cover rounded"
                   />

--- a/src/components/layout/DropTheme/DropThemeScene.jsx
+++ b/src/components/layout/DropTheme/DropThemeScene.jsx
@@ -18,13 +18,13 @@ export default function DropThemeScene({ category }) {
           className="absolute inset-0 w-full h-full object-cover"
         >
           <source
-            src={`http://localhost:8080${category.teaserVideoUrl}`}
+            src={`${import.meta.env.VITE_MEDIA_URL}${category.teaserVideoUrl}`}
             type="video/mp4"
           />
         </video>
       ) : category.coverImageUrl ? (
         <img
-          src={`http://localhost:8080${category.coverImageUrl}`}
+          src={`${import.meta.env.VITE_MEDIA_URL}${category.coverImageUrl}`}
           alt="drop background"
           className="absolute inset-0 w-full h-full object-cover"
         />

--- a/src/components/layout/Header/CartOverlay/CartOverlay.jsx
+++ b/src/components/layout/Header/CartOverlay/CartOverlay.jsx
@@ -63,7 +63,7 @@ export default function CartOverlay() {
               return (
                 <div key={id} className="flex gap-5 items-center mb-8">
                   <img
-                    src={`http://localhost:8080${product.featuredImageUrl}`}
+                    src={`${import.meta.env.VITE_MEDIA_URL}${product.featuredImageUrl}`}
                     className="w-32 h-32 object-cover rounded"
                   />
 

--- a/src/components/product/HighlightedProducts.jsx
+++ b/src/components/product/HighlightedProducts.jsx
@@ -7,7 +7,7 @@ export default function HighlightedProducts() {
 
   useEffect(() => {
     axios
-      .get("http://localhost:8080/api/products/featured")
+      .get(`${import.meta.env.VITE_API_URL}/products/featured`)
       .then((res) => setProducts(res.data))
       .catch((err) => console.error("Failed to fetch featured products", err));
   }, []);

--- a/src/components/product/ProductBoxPresentation.jsx
+++ b/src/components/product/ProductBoxPresentation.jsx
@@ -25,7 +25,7 @@ export default function ProductBoxPresentation({ product }) {
       <div className="relative aspect-[5/5] bg-stone rounded-sm overflow-hidden transition-all duration-300 hover:shadow-md">
         {/* Product Image */}
         <img
-          src={`http://localhost:8080${featuredImage?.url}`}
+          src={`${import.meta.env.VITE_MEDIA_URL}${featuredImage?.url}`}
           alt={product.name}
           className="w-full h-full object-contain p-4 transition-opacity duration-500"
         />

--- a/src/components/product/ProductHero.jsx
+++ b/src/components/product/ProductHero.jsx
@@ -54,7 +54,7 @@ export default function ProductHero({
             className="order-1 md:order-2 w-full md:w-1/2 flex items-center justify-center"
           >
             <img
-              src={`http://localhost:8080${featuredImage.url}`}
+              src={`${import.meta.env.VITE_MEDIA_URL}${featuredImage.url}`}
               alt={product.name}
               className="w-full max-w-[350px] md:max-w-full h-auto object-contain rounded-lg"
             />

--- a/src/components/product/ProductImage/ProductImageGallery.jsx
+++ b/src/components/product/ProductImage/ProductImageGallery.jsx
@@ -35,7 +35,7 @@ export default function ProductImageGallery({ productId, images, onRefresh }) {
           }`}
         >
           <img
-            src={`http://localhost:8080${img.url}`}
+            src={`${import.meta.env.VITE_MEDIA_URL}${img.url}`}
             alt="Product"
             className="object-cover w-full h-full"
           />

--- a/src/pages/AllProducts.jsx
+++ b/src/pages/AllProducts.jsx
@@ -57,7 +57,7 @@ export default function AllProducts() {
           backgroundImage: `url(${
             selectedCategory === "1"
               ? "/src/assets/images/all-products.jpg"
-              : `http://localhost:8080${selectedCategoryObj?.coverImageUrl}`
+              : `${import.meta.env.VITE_MEDIA_URL}${selectedCategoryObj?.coverImageUrl}`
           })`,
         }}
       >

--- a/src/pages/ProductPage.jsx
+++ b/src/pages/ProductPage.jsx
@@ -76,7 +76,7 @@ export default function ProductPage() {
             categoryId={category.id}
             videoUrl={
               category.teaserVideoUrl
-                ? `http://localhost:8080${category.teaserVideoUrl}`
+                ? `${import.meta.env.VITE_MEDIA_URL}${category.teaserVideoUrl}`
                 : null
             }
           />

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-const API_URL = "http://localhost:8080";
+const API_URL = import.meta.env.VITE_API_URL;
 
 export async function loginUser(email, password) {
   const response = await axios.post(

--- a/src/services/axiosInstance.js
+++ b/src/services/axiosInstance.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const axiosInstance = axios.create({
-  baseURL: "http://localhost:8080/api",
+  baseURL: import.meta.env.VITE_API_URL,
 });
 
 axiosInstance.interceptors.request.use((config) => {


### PR DESCRIPTION
## Summary
- ignore .env files and provide example
- read base URL from `import.meta.env.VITE_API_URL`
- use `VITE_MEDIA_URL` for media assets
- document env vars in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684056ca8168832f9f1948116684f5b2